### PR TITLE
fix gcloud dependency error

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@main
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@main
+        uses: google-github-actions/setup-gcloud@v1
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
Fix the following error.

```
Error: Unable to resolve action `google-github-actions/setup-gcloud@master`, unable to find version `master`
```

the target repository has changed the branch name from master to main.
ref. https://github.com/google-github-actions/setup-gcloud/commit/db80c6a94ecda9e6b13937340c8c64ab24776fde

we should use `v1` versioning instead of `matser` or `main`.
ref. https://github.com/google-github-actions/setup-gcloud#usage