### PR TITLE
Fix Google Cloud authentication logic

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,9 +12,11 @@ jobs:
       - name: 'Authenticate Google Cloud with Service Account'
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
       - name: 'Set up Cloud SDK'
         uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: Add Permission to Script
         working-directory: ./
         run: chmod +x ./scripts/apply.sh

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,13 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: actions/checkout@v3
+      - name: 'Authenticate Google Cloud with Service Account'
+        uses: google-github-actions/auth@v1
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_JSON }}
+      - name: 'Set up Cloud SDK'
+        uses: google-github-actions/setup-gcloud@v1
       - name: Add Permission to Script
         working-directory: ./
         run: chmod +x ./scripts/apply.sh

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@
     - role/BigQuery.jobUser
   - export: json key file
 - GitHub Actions
-  - secrets.GCP_PROJECT_ID
-  - secrets.GCP_SA_KEY
+  - `secrets.GCP_PROJECT_ID`
+    - Project ID (not project number) of the Google Cloud project
+  - `secrets.GCP_SA_KEY`
+    - Set json key (preferred to compress in single-line)
 
 ## Usage
 


### PR DESCRIPTION
Followed guides on:
- https://github.com/google-github-actions/setup-gcloud
- https://github.com/google-github-actions/auth

~Also you need to set repository secret `GCP_SERVICE_ACCOUNT_JSON` that contains one-line JSON string of GCP service account key.~